### PR TITLE
Removes the need to have an auth_file to use RDStationClient

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import requests_mock
 import pytest
 
 
-@pytest.yield_fixture()
+@pytest.fixture()
 def mock_api():
     with requests_mock.Mocker() as m:
         m.get(

--- a/tests/test_rdstation_client.py
+++ b/tests/test_rdstation_client.py
@@ -95,12 +95,14 @@ def test__get_json_response_200s(mock_api):
     except ExceptionRDStationClientResponse:
         pass
 
+
 def test_not_file_auth():
     try:
         RDStationClient()
         raise Exception('not expected')
     except ExceptionRDStationClient:
         pass
+
 
 def test_create_tokens_1():
     rdc = _create_rdc()

--- a/tests/test_rdstation_client.py
+++ b/tests/test_rdstation_client.py
@@ -95,6 +95,12 @@ def test__get_json_response_200s(mock_api):
     except ExceptionRDStationClientResponse:
         pass
 
+def test_not_file_auth():
+    try:
+        RDStationClient()
+        raise Exception('not expected')
+    except ExceptionRDStationClient:
+        pass
 
 def test_create_tokens_1():
     rdc = _create_rdc()

--- a/tests/test_rdstation_client.py
+++ b/tests/test_rdstation_client.py
@@ -21,19 +21,23 @@ def _create_rdc(file_auth='test_file_auth.json', console_input=False):
     return rdc
 
 
+def _create_rdc_from_params(**kwargs):
+    return RDStationClient(**kwargs)
+
+
 def test_exception_rdstation_client_response_1():
     obj = ExceptionRDStationClientResponse(json.dumps({
         'errors': {
             'api_identifier': [{
                 'error_message': 'a field with '
-                "'api_identifier' = "
-                "'cf_my_custom_field' already "
-                'exists',
+                                 "'api_identifier' = "
+                                 "'cf_my_custom_field' already "
+                                 'exists',
                 'error_type': 'TAKEN'}],
             'name': {'pt-BR': [{
                 'error_message': "a field with 'name' = 'Meu "
-                "campo customizado' already "
-                'exists',
+                                 "campo customizado' already "
+                                 'exists',
                 'error_type': 'TAKEN'
             }]}}
     }))
@@ -46,11 +50,11 @@ def test_exception_rdstation_client_response_1():
 def test_exception_rdstation_client_response_2():
     obj = ExceptionRDStationClientResponse(json.dumps({
         'errors': {
-                'error_message': 'a field with '
-                "'api_identifier' = "
-                "'cf_my_custom_field' already "
-                'exists',
-                'error_type': 'TAKEN'}
+            'error_message': 'a field with '
+                             "'api_identifier' = "
+                             "'cf_my_custom_field' already "
+                             'exists',
+            'error_type': 'TAKEN'}
     }))
     sobj = str(obj)
     assert 'ExceptionRDStationClientResponse(' in sobj
@@ -92,14 +96,6 @@ def test__get_json_response_200s(mock_api):
         pass
 
 
-def test_not_file_auth():
-    try:
-        RDStationClient()
-        raise Exception('not expected')
-    except ExceptionRDStationClient:
-        pass
-
-
 def test_create_tokens_1():
     rdc = _create_rdc()
     rdc.access_token = None
@@ -133,8 +129,73 @@ def test_create_tokens_3():  # mock_api
         print(':)')
 
 
-def test_encode_all_unicode():
+def test_create_rdc_can_auth_1():
+    rdc = _create_rdc_from_params(
+        file_auth='somefile',
+    )
+    assert isinstance(rdc, RDStationClient)
 
+
+def test_create_rdc_can_auth_2():
+    rdc = _create_rdc_from_params(
+        client_id='client_id',
+        client_secret='client_secret',
+        refresh_token='refresh_token'
+    )
+    assert isinstance(rdc, RDStationClient)
+
+
+def test_create_rdc_can_auth_3():
+    rdc = _create_rdc_from_params(
+        client_id='client_id',
+        client_secret='client_secret',
+        access_token='access_token',
+        refresh_token='refresh_token',
+    )
+    assert isinstance(rdc, RDStationClient)
+
+
+def test_create_rdc_can_auth_4():
+    rdc = _create_rdc_from_params(
+        client_id='client_id',
+        client_secret='client_secret',
+        access_token='access_token',
+        code='code',
+    )
+    assert isinstance(rdc, RDStationClient)
+
+
+def test_create_rdc_can_auth_5():
+    rdc = _create_rdc_from_params(
+        client_id='client_id',
+        client_secret='client_secret',
+        code='code',
+    )
+    assert isinstance(rdc, RDStationClient)
+
+
+def test_create_rdc_cannot_auth_1():
+    try:
+        _create_rdc_from_params(
+            client_id='client_id',
+            client_secret='client_secret',
+        )
+        raise Exception('not expected')
+    except ExceptionRDStationClient:
+        pass
+
+
+def test_create_rdc_cannot_auth_2():
+    try:
+        _create_rdc_from_params(
+            access_token='access_token'
+        )
+        raise Exception('not expected')
+    except ExceptionRDStationClient:
+        pass
+
+
+def test_encode_all_unicode():
     class FakeUnicode(object):
         @staticmethod
         def encode(encoding):
@@ -338,7 +399,6 @@ def test_funnels_put_by_uuid(mock_api):
         'contact_owner_email': ''
     })
     assert isinstance(resp, dict)
-
 
 # # @requests_mock.mock()
 # def test_contacts_patch(m):


### PR DESCRIPTION
This PR proposes a change to the RDStationClient where the same authentication parameters gathered from the ```auth_file``` can be provided programatically.

Currently, the RDStation Client instantiation depends on the ```auth_file```, throwing an Exception when it is not available.
https://github.com/sxslex/rdstation-client/blob/c7fbf5d1696c6cace511fd100b393540beff447b/rdstation_client/__init__.py#L53-L54

That makes it difficult to use this package on a scenario where there is no persistent storage available - such as when using it in a "Function" on Azure, Google Cloud Platform or AWS.

This PR will make this use case available:

```python
import os

client_id = os.getenv('client_id')
client_secret = os.getenv('client_secret')
access_token = os.getenv('access_token')
refresh_token = os.getenv('refresh_token')

rdc = rdstation_client.RDStationClient(
    client_id=client_id,
    client_secret=client_secret,
    access_token=access_token,
    refresh_token=refresh_token
)
```

Since this lib was cleverly designed to create tokens when necessary, some validations were added to the instantiation process. 

No API-breaking changes were made and the necessary testes were added.

Please let me know of your comments.


